### PR TITLE
[IMP] stock_storage_type

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -243,7 +243,7 @@ class StockLocation(models.Model):
     def _existing_planned_moves(self, products=None, lot=None):
         base_domain = [
             ("location_dest_id", "child_of", self.id),
-            ("move_id.state", "not in", ("draft", "cancel", "done")),
+            ("state", "not in", ("draft", "cancel", "done")),
         ]
         domain = self._prepare_existing_domain(base_domain, products=products, lot=lot)
         return self.env["stock.move.line"].search(domain, limit=1)

--- a/stock_storage_type/models/stock_package_level.py
+++ b/stock_storage_type/models/stock_package_level.py
@@ -47,6 +47,8 @@ class StockPackageLevel(models.Model):
                 # excluded by the check on incoming stock moves
                 intersect_locations |= pack_level.location_dest_id
                 pack_level.allowed_location_dest_ids = intersect_locations.ids
+            elif isinstance(pack_level.id, models.NewId):
+                pack_level.allowed_location_dest_ids = pack_level.picking_id.location_dest_id.ids
             else:
                 pack_level.allowed_location_dest_ids = (
                     picking_child_location_dest_ids.ids
@@ -64,9 +66,9 @@ class StockPackageLevel(models.Model):
             ]
         )
         all_allowed_locations = set()
+        products = self.mapped('move_line_ids.product_id')
         for pack_loc in package_locations:
             pref_loc = pack_loc.location_id
-            products = self.mapped("move_line_ids.product_id")
             storage_locations = pref_loc.get_storage_locations(products=products)
             allowed_locations = storage_locations.select_allowed_locations(
                 self.package_id.package_storage_type_id,


### PR DESCRIPTION
improve perfs
* in _compute_allowed_location_dest_ids handle the case of a missing pack level, and short cut
* move a mapped() call out of a loop
* use the stored related field state of stock.move.line instead of a dotted path in the search domain