### PR TITLE
improve perfs

### DIFF
--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -11,11 +11,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": [
-        "base_m2m_custom_field",
-        "stock_location_children",
-        "stock_quant_package_dimension",
-    ],
+    "depends": ["base_m2m_custom_field", "stock_quant_package_dimension"],
     "data": [
         "security/ir.model.access.csv",
         "views/product_packaging.xml",

--- a/stock_storage_type/i18n/stock_storage_type.pot
+++ b/stock_storage_type/i18n/stock_storage_type.pot
@@ -14,11 +14,6 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_storage_type
-#: model:ir.model.fields,field_description:stock_storage_type.field_stock_location_storage_type__allowed_location_ids
-msgid "Allowed Location"
-msgstr ""
-
-#. module: stock_storage_type
 #: model:ir.model.fields,field_description:stock_storage_type.field_stock_location__allowed_stock_location_storage_type_ids
 msgid "Allowed Stock Location Storage Type"
 msgstr ""

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -256,13 +256,13 @@ class StockLocation(models.Model):
             pertinent_loc_storagetype_domain += [
                 '|',
                 ('max_height', '=', 0),
-                ('max_height', '>', quants.package_id.height),
+                ('max_height', '>=', quants.package_id.height),
             ]
         if quants.package_id.pack_weight:
             pertinent_loc_storagetype_domain += [
                 '|',
                 ('max_weight', '=', 0),
-                ('max_weight', '>', quants.package_id.pack_weight),
+                ('max_weight', '>=', quants.package_id.pack_weight),
             ]
         _logger.debug('pertinent storage type domain: %s',
                       pertinent_loc_storagetype_domain)

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -129,9 +129,10 @@ class StockLocation(models.Model):
     def _compute_location_is_empty(self):
         for rec in self:
             if (
-                    sum(rec.quant_ids.mapped("quantity"))
-                    or rec.in_move_ids
-                    or rec.children_in_move_line_ids
+                sum(rec.quant_ids.mapped("quantity"))
+                or rec.in_move_ids
+                or rec.in_move_line_ids
+                or rec.children_in_move_line_ids
             ):
                 rec.location_is_empty = False
             else:

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -63,12 +63,17 @@ class StockLocation(models.Model):
 
     in_move_ids = fields.One2many(
         'stock.move', 'location_dest_id',
-        domain=[('state', 'not in', ('draft', 'done', 'cancel'))],
+        domain=[
+            ('state', 'in', ('waiting', 'confirmed', 'partially_available', 'assigned'))
+        ],
         help="technical field: the pending incoming stock.moves in the location",
     )
+
     in_move_line_ids = fields.One2many(
         'stock.move.line', 'location_dest_id',
-        domain=[('state', 'not in', ('draft', 'done', 'cancel'))],
+        domain=[
+            ('state', 'in', ('waiting', 'confirmed', 'partially_available', 'assigned'))
+        ],
         help="technical field: the pending incoming "
         "stock.move.lines in the location",
     )

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -236,7 +236,7 @@ class StockLocation(models.Model):
         allowed = self.select_allowed_locations(package_storage_type, quants, products, limit=1)
         return allowed
 
-    def _domain_location_storage_type_constraints(self, compatible_locations, package_storage_type, quants, products):
+    def _domain_location_storage_type_constraints(self, package_storage_type, quants, products):
         """Compute the domain for the location storage type which match the package
         storage type
 
@@ -245,10 +245,8 @@ class StockLocation(models.Model):
         # There can be multiple location storage types for a given
         # location, so we need to filter on the ones relative to the package
         # we consider.
-        StockLocationStorageType = self.env['stock.location.storage.type']
-        compatible_location_storage_types = StockLocationStorageType.search(
-            [('allowed_location_ids', 'in', compatible_locations.ids)]
-        )
+        compatible_location_storage_types = self.mapped("allowed_location_storage_type_ids")
+
         pertinent_loc_storagetype_domain = [
             ('id', 'in', compatible_location_storage_types.ids),
             ('package_storage_type_ids', '=', package_storage_type.id),
@@ -297,10 +295,11 @@ class StockLocation(models.Model):
             ]
         )
         pertinent_loc_s_t_domain = (
-            LocStorageType._domain_location_storage_type_constraints(
-                compatible_locations, package_storage_type, quants, products
+            compatible_locations._domain_location_storage_type_constraints(
+                package_storage_type, quants, products
             )
         )
+
         pertinent_loc_storage_types = LocStorageType.search(
             pertinent_loc_s_t_domain
         )

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -4,9 +4,8 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.osv.expression import AND, OR
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class StockLocation(models.Model):
@@ -55,6 +54,81 @@ class StockLocation(models.Model):
         "location_id",
         string="Storage locations sequences",
     )
+    location_is_empty = fields.Boolean(
+        compute="_compute_location_is_empty",
+        store=True,
+        help="technical field: True if the location is empty "
+        "and there is no pending incoming products in the location"
+    )
+
+    in_move_ids = fields.One2many(
+        'stock.move', 'location_dest_id',
+        domain=[('state', 'not in', ('draft', 'done', 'cancel'))],
+        help="technical field: the pending incoming stock.moves in the location",
+    )
+    in_move_line_ids = fields.One2many(
+        'stock.move.line', 'location_dest_id',
+        domain=[('state', 'not in', ('draft', 'done', 'cancel'))],
+        help="technical field: the pending incoming "
+        "stock.move.lines in the location",
+    )
+    children_in_move_line_ids = fields.Many2many(
+        'stock.move.line',
+        _compute='_compute_children_in_move_line_ids',
+        store=True,
+        help="technical field: the pending incoming stock.move.lines "
+        "in the location or children locations",
+    )
+    location_will_contain_lot_ids = fields.Many2many(
+        'stock.production.lot',
+        store=True,
+        compute="_compute_location_will_contain_lot_ids",
+        help="technical field: list of stock.production.lots in "
+        "the location, either now or in pending operations"
+    )
+    location_will_contain_product_ids = fields.Many2many(
+        'product.product',
+        store=True,
+        compute="_compute_location_will_contain_product_ids",
+        help="technical field: list of products in "
+        "the location, either now or in pending operations"
+    )
+
+    @api.depends('child_ids.in_move_line_ids')
+    def _compute_children_in_move_line_ids(self):
+        for rec in self:
+            rec.children_in_move_line_ids = (
+                rec.mapped('child_ids.in_move_line_ids') | rec.in_move_line_ids
+            )
+
+    @api.depends('quant_ids', 'in_move_ids', 'children_in_move_line_ids')
+    def _compute_location_will_contain_product_ids(self):
+        for rec in self:
+            rec.location_will_contain_product_ids = (
+                rec.mapped('quant_ids.product_id')
+                | rec.mapped("in_move_ids.product_id")
+                | rec.mapped("children_in_move_line_ids.product_id")
+            )
+
+    @api.depends('quant_ids', 'children_in_move_line_ids')
+    def _compute_location_will_contain_lot_ids(self):
+        for rec in self:
+            rec.location_will_contain_lot_ids = (
+                rec.mapped('quant_ids.lot_id')
+                | rec.mapped("children_in_move_line_ids.lot_id")
+            )
+
+    @api.depends('quant_ids', 'in_move_ids', 'in_move_line_ids')
+    def _compute_location_is_empty(self):
+        for rec in self:
+            if (
+                    rec.quant_ids
+                    or rec.in_move_ids
+                    or rec.children_in_move_line_ids
+            ):
+                rec.location_is_empty = False
+            else:
+                rec.location_is_empty = True
 
     @api.depends(
         "location_storage_type_ids",
@@ -98,45 +172,51 @@ class StockLocation(models.Model):
         package_storage_type = False
         if quant:
             package_storage_type = quant.package_id.package_storage_type_id
-            logger.debug(
+            _logger.debug(
                 "Computing putaway for pack %s (%s)"
                 % (quant.package_id.name, quant.package_id)
             )
+        # I'm not sure about this. I had to add the line, because there is a
+        # second call to get_putaway_strategy which is made a 'leaf' location
+        # as putaway_location which does not match the package storage type in
+        # the project. This could be caused by another module, I'm not sure...
         if not package_storage_type:
             return putaway_location
         dest_location = putaway_location or self
+        _logger.debug('putaway location: %s', dest_location.name)
         package_locations = self.env["stock.storage.location.sequence"].search(
             [
                 ("package_storage_type_id", "=", package_storage_type.id),
                 ("location_id", "child_of", dest_location.ids),
             ]
         )
-        for pack_loc in package_locations:
-            pref_loc = pack_loc.location_id
+        if not package_locations:
+            return dest_location
+        for pref_loc in package_locations.mapped('location_id'):
             if (
                 pref_loc.pack_putaway_strategy == "none"
-                and pref_loc._package_storage_type_allowed(
+                and pref_loc.select_allowed_locations(
                     package_storage_type, quant, product
                 )
             ):
-                logger.debug(
+                _logger.debug(
                     "No putaway strategy defined on location %s and package "
                     "storage type %s allowed."
                     % (pref_loc.complete_name, package_storage_type.name)
                 )
                 return pref_loc
             storage_locations = pref_loc.get_storage_locations(products=product)
-            logger.debug("Storage locations selected: %s" % storage_locations)
+            _logger.debug("Storage locations selected: %s" % storage_locations)
             allowed_location = storage_locations.select_first_allowed_location(
                 package_storage_type, quant, product
             )
             if allowed_location:
-                logger.debug(
+                _logger.debug(
                     "Applied putaway strategy to location %s"
                     % allowed_location.complete_name
                 )
                 return allowed_location
-        logger.debug(
+        _logger.debug(
             "Could not find a valid putaway location, fallback to %s"
             % putaway_location.complete_name
         )
@@ -153,125 +233,98 @@ class StockLocation(models.Model):
         return locations
 
     def select_first_allowed_location(self, package_storage_type, quants, products):
-        for location in self:
-            if location._package_storage_type_allowed(
-                package_storage_type, quants, products
-            ):
-                return location
-        return self.browse()
+        allowed = self.select_allowed_locations(package_storage_type, quants, products, limit=1)
+        return allowed
 
-    def select_allowed_locations(self, package_storage_type, quants, products):
+    def select_allowed_locations(self, package_storage_type, quants, products, limit=None):
         # TODO merge with select_first_allowed_location ?
-        allowed_ids = set()
-        for location in self:
-            if location._package_storage_type_allowed(
-                package_storage_type, quants, products
-            ):
-                allowed_ids.add(location.id)
-        return self.browse(allowed_ids)
+        # We have package who may be placed in a stock.location
+        #
+        # 1. On the stock.location there are location_storage_type and on the
+        # packages there are package_storage_type. Between both, there's a m2m
+        # who says which package ST can be placed in which location ST
+        #
+        # 2. On a location_ST there are some additional restrictions: a -
+        # capacity (volume / height / weight) and b - properties (boolean
+        # flags: only empty, don't mix lots, don't mix products)
+        StockLocationStorageType = self.env['stock.location.storage.type']
+        _logger.debug(
+            'select allowed location for package storage type %s (q=%s, p=%s)',
+            package_storage_type.name, quants, products.mapped('name')
+        )
+        # 1: filter locations on compatible storage type
+        compatible_locations = self.search(
+            [
+                ('id', 'in', self.ids),
+                (
+                    'allowed_location_storage_type_ids',
+                    'in',
+                    package_storage_type.location_storage_type_ids.ids
+                ),
+            ]
+        )
+        # now find the location storage types among the compatible locations
+        # which match the package storage type (careful, there can be multiple
+        # location storage types for a given location, so we need to filter on
+        # the ones relative to the package we consider).
+        # We also check the "capacity" constraints (height and weight)
+        compatible_location_storage_types = StockLocationStorageType.search(
+            [('allowed_location_ids', 'in', compatible_locations.ids)]
+        )
+        pertinent_loc_storagetype_domain = [
+            ('id', 'in', compatible_location_storage_types.ids),
+            ('package_storage_type_ids', '=', package_storage_type.id),
+        ]
+        if quants.package_id.height:
+            pertinent_loc_storagetype_domain += [
+                '|',
+                ('max_height', '=', 0),
+                ('max_height', '>', quants.package_id.height),
+            ]
+        if quants.package_id.pack_weight:
+            pertinent_loc_storagetype_domain += [
+                '|',
+                ('max_weight', '=', 0),
+                ('max_weight', '>', quants.package_id.pack_weight),
+            ]
+
+        pertinent_loc_storage_types = StockLocationStorageType.search(
+            pertinent_loc_storagetype_domain
+        )
+        _logger.debug('pertinent storage type domain: %s', pertinent_loc_storagetype_domain)
+
+        # now loop over the pertinent location storage types (there should be
+        # few of them) and check for properties to find suitable locations
+        valid_location_ids = set()
+        for loc_storage_type in pertinent_loc_storage_types:
+            location_domain = [
+                ('id', 'in', compatible_locations.ids),
+                ('allowed_location_storage_type_ids', '=', loc_storage_type.id),
+            ]
+            if loc_storage_type.only_empty:
+                location_domain.append(
+                    ('location_is_empty', '=', True)
+                )
+            if loc_storage_type.do_not_mix_products:
+                location_domain.append(
+                    ('location_will_contain_product_ids', 'not in', products.ids)
+                )
+                if loc_storage_type.do_not_mix_lots:
+                    lots = quants.mapped('lot_id')
+                    location_domain.append(
+                        ('location_will_contain_lot_ids', 'not in', lots.ids),
+                    )
+            locations = self.search(location_domain, limit=limit)
+            valid_location_ids |= set(locations.ids)
+        valid_locations = self.env['stock.location'].search(
+            [('id', 'in', list(valid_location_ids))], limit=limit
+        )
+        _logger.debug(
+            'select allowed location for package storage type %s (q=%s, p=%s) found %d locations',
+            package_storage_type.name, quants, products.mapped('name'), len(valid_locations)
+        )
+        return valid_locations
 
     def _get_ordered_children_locations(self):
         # Call sorted() to ensure the _order is respected
         return self.children_ids.sorted()
-
-    def _package_storage_type_allowed(self, package_storage_type, quants, products):
-        self.ensure_one()
-        allowed_loc_storage_types = self.allowed_location_storage_type_ids
-        matching_location_storage_types = allowed_loc_storage_types.filtered(
-            lambda slst: package_storage_type in slst.package_storage_type_ids
-        )
-        allowed_location_storage_types = self.filter_restrictions(
-            matching_location_storage_types, quants, products
-        )
-        return (
-            not self.allowed_location_storage_type_ids or allowed_location_storage_types
-        )
-
-    def filter_restrictions(self, matching_location_storage_types, quants, products):
-        allowed_location_storage_types = self.env["stock.location.storage.type"]
-        for location_storage_type in matching_location_storage_types:
-            if self._filter_properties(
-                location_storage_type, quants, products
-            ) and self._filter_capacity(location_storage_type, quants):
-                allowed_location_storage_types |= location_storage_type
-        return allowed_location_storage_types
-
-    def _filter_properties(self, location_storage_type, quants, products):
-        if location_storage_type.only_empty:
-            if (
-                not self._existing_quants()
-                and not self._existing_planned_move_lines()
-                and not self._existing_planned_moves()
-            ):
-                return location_storage_type
-        elif location_storage_type.do_not_mix_products:
-            if location_storage_type.do_not_mix_lots:
-                lot = quants.mapped("lot_id")
-                if len(lot) > 1:
-                    return False
-                if not self._existing_quants(
-                    products=products, lot=lot
-                ) and not self._existing_planned_move_lines(products=products, lot=lot):
-                    return location_storage_type
-            else:
-                if (
-                    not self._existing_quants(products=products)
-                    and not self._existing_planned_move_lines(products=products)
-                    and not self._existing_planned_moves(products=products)
-                ):
-                    return location_storage_type
-        else:
-            return location_storage_type
-
-    def _filter_capacity(self, location_storage_type, quants):
-        if self._max_height_allowed(
-            location_storage_type, quants
-        ) and self._max_weight_allowed(location_storage_type, quants):
-            return location_storage_type
-        else:
-            return self.env["stock.location.storage.type"]
-
-    def _max_height_allowed(self, location_storage_type, quants):
-        height = quants.package_id.height
-        max_height = location_storage_type.max_height
-        return not (max_height and height and height > max_height)
-
-    def _max_weight_allowed(self, location_storage_type, quants):
-        pack_weight = quants.package_id.pack_weight
-        max_weight = location_storage_type.max_weight
-        return not (max_weight and pack_weight and pack_weight > max_weight)
-
-    def _existing_quants(self, products=None, lot=None):
-        base_domain = [("location_id", "child_of", self.id)]
-        domain = self._prepare_existing_domain(base_domain, products=products, lot=lot)
-        return self.env["stock.quant"].search(domain, limit=1)
-
-    def _existing_planned_move_lines(self, products=None, lot=None):
-        base_domain = [
-            ("location_dest_id", "child_of", self.id),
-            ("state", "in", ("waiting", "partially_available", "assigned")),
-        ]
-        domain = self._prepare_existing_domain(base_domain, products=products, lot=lot)
-        return self.env["stock.move.line"].search(domain, limit=1)
-
-    def _existing_planned_moves(self, products=None):
-        if self.child_ids:
-            # If a location is a leaf, it's a "bin", we know that the move line will
-            # be in this exact location. If it has sub-locations, we can't be sure
-            # where it will go and we don't want to restrict based on this.
-            return self.env["stock.move"].browse()
-        base_domain = [
-            ("location_dest_id", "=", self.id),
-            ("state", "in", ("waiting", "confirmed")),
-        ]
-        domain = self._prepare_existing_domain(base_domain, products=products)
-        return self.env["stock.move"].search(domain, limit=1)
-
-    def _prepare_existing_domain(self, base_domain, products=None, lot=None):
-        domain = base_domain
-        if products is not None:
-            extra_domain = [("product_id", "not in", products.ids)]
-            if lot is not None:
-                extra_domain = OR([extra_domain, [("lot_id", "!=", lot.id)]])
-            domain = AND([domain, extra_domain])
-        return domain

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -192,6 +192,7 @@ class StockLocation(models.Model):
         )
         if not package_locations:
             return dest_location
+
         for pref_loc in package_locations.mapped('location_id'):
             if (
                 pref_loc.pack_putaway_strategy == "none"

--- a/stock_storage_type/models/stock_location_storage_type.py
+++ b/stock_storage_type/models/stock_location_storage_type.py
@@ -122,6 +122,10 @@ class StockLocationStorageType(models.Model):
             ('id', 'in', candidate_locations.ids),
             ('allowed_location_storage_type_ids', '=', self.id),
         ]
+        # TODO this method and domain is applied once per storage type. If it's
+        # too slow at some point, we could group the storage types by similar
+        # configuration (only_empty, do_not_mix_products, do_not_mix_lots) and
+        # do a single query per set of options
         if self.only_empty:
             location_domain.append(
                 ('location_is_empty', '=', True)
@@ -136,7 +140,7 @@ class StockLocationStorageType(models.Model):
                 # then all the new moves for product B will be allowed in the
                 # location.
                 ('location_will_contain_product_ids', 'in', products.ids),
-                ('location_will_contain_product_ids', '=', [])
+                ('location_will_contain_product_ids', '=', False)
             ]
             if self.do_not_mix_lots:
                 lots = quants.mapped('lot_id')
@@ -144,6 +148,6 @@ class StockLocationStorageType(models.Model):
                     '|',
                     # same comment as for the products
                     ('location_will_contain_lot_ids', 'in', lots.ids),
-                    ('location_will_contain_lot_ids', '=', []),
+                    ('location_will_contain_lot_ids', '=', False),
                 ]
         return location_domain

--- a/stock_storage_type/models/stock_location_storage_type.py
+++ b/stock_storage_type/models/stock_location_storage_type.py
@@ -121,35 +121,33 @@ class StockLocationStorageType(models.Model):
         """
         self.ensure_one()
         location_domain = [
-            ('id', 'in', candidate_locations.ids),
-            ('allowed_location_storage_type_ids', '=', self.id),
+            ("id", "in", candidate_locations.ids),
+            ("allowed_location_storage_type_ids", "=", self.id),
         ]
         # TODO this method and domain is applied once per storage type. If it's
         # too slow at some point, we could group the storage types by similar
         # configuration (only_empty, do_not_mix_products, do_not_mix_lots) and
         # do a single query per set of options
         if self.only_empty:
-            location_domain.append(
-                ('location_is_empty', '=', True)
-            )
+            location_domain.append(("location_is_empty", "=", True))
         if self.do_not_mix_products:
             location_domain += [
-                '|',
+                "|",
                 # Ideally, we would like a domain which is a strict comparison:
                 # if we do not mix products, we should be able to filter on ==
                 # product.id. Here, if we can create a move for product B and
                 # set it's destination in a location already used by product A,
                 # then all the new moves for product B will be allowed in the
                 # location.
-                ('location_will_contain_product_ids', 'in', products.ids),
-                ('location_will_contain_product_ids', '=', False)
+                ("location_will_contain_product_ids", "in", products.ids),
+                ("location_will_contain_product_ids", "=", False),
             ]
             if self.do_not_mix_lots:
-                lots = quants.mapped('lot_id')
+                lots = quants.mapped("lot_id")
                 location_domain += [
-                    '|',
+                    "|",
                     # same comment as for the products
-                    ('location_will_contain_lot_ids', 'in', lots.ids),
-                    ('location_will_contain_lot_ids', '=', False),
+                    ("location_will_contain_lot_ids", "in", lots.ids),
+                    ("location_will_contain_lot_ids", "=", False),
                 ]
         return location_domain

--- a/stock_storage_type/models/stock_location_storage_type.py
+++ b/stock_storage_type/models/stock_location_storage_type.py
@@ -50,11 +50,13 @@ class StockLocationStorageType(models.Model):
     )
     max_height = fields.Float(
         string="Max height (mm)",
+        default=0.0,
         help="If defined, moves to the destination location will only be "
         "allowed if the packaging height is lower than this maximum.",
     )
     max_weight = fields.Float(
         string="Max weight (kg)",
+        default=0.0,
         help="If defined, moves to the destination location will only be "
         "allowed if the packaging wight is lower than this maximum.",
     )

--- a/stock_storage_type/models/stock_package_level.py
+++ b/stock_storage_type/models/stock_package_level.py
@@ -19,7 +19,7 @@ class StockPackageLevel(models.Model):
         "package_id.package_storage_type_id.location_storage_type_ids",
         "package_id.package_storage_type_id.storage_location_sequence_ids",
         "package_id.package_storage_type_id.storage_location_sequence_ids.location_id",
-        "package_id.package_storage_type_id.storage_location_sequence_ids.location_id.children_ids",  # noqa
+        "package_id.package_storage_type_id.storage_location_sequence_ids.location_id.leaf_location_ids",  # noqa
         # Dependency on quant_ids managed by cache invalidation on create/write
         "picking_id",
         "picking_id.location_dest_id",

--- a/stock_storage_type/models/stock_package_level.py
+++ b/stock_storage_type/models/stock_package_level.py
@@ -48,7 +48,9 @@ class StockPackageLevel(models.Model):
                 intersect_locations |= pack_level.location_dest_id
                 pack_level.allowed_location_dest_ids = intersect_locations.ids
             elif isinstance(pack_level.id, models.NewId):
-                pack_level.allowed_location_dest_ids = pack_level.picking_id.location_dest_id.ids
+                pack_level.allowed_location_dest_ids = (
+                    pack_level.picking_id.location_dest_id.ids
+                )
             else:
                 pack_level.allowed_location_dest_ids = (
                     picking_child_location_dest_ids.ids
@@ -66,7 +68,7 @@ class StockPackageLevel(models.Model):
             ]
         )
         all_allowed_locations = set()
-        products = self.mapped('move_line_ids.product_id')
+        products = self.mapped("move_line_ids.product_id")
         for pack_loc in package_locations:
             pref_loc = pack_loc.location_id
             storage_locations = pref_loc.get_storage_locations(products=products)

--- a/stock_storage_type/tests/test_storage_type.py
+++ b/stock_storage_type/tests/test_storage_type.py
@@ -9,6 +9,8 @@ class TestStorageType(SavepointCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
         cls.pallets_location_storage_type = cls.env.ref(
             "stock_storage_type.location_storage_type_pallets"
         )
@@ -91,3 +93,38 @@ class TestStorageType(SavepointCase):
         self.pallets_location_storage_type.only_empty = False
         self.pallets_location_storage_type.do_not_mix_products = True
         self.pallets_location_storage_type.do_not_mix_lots = True
+
+    def test_location_leaf_locations(self):
+        cardboxes_xmlids = [
+            "stock_storage_type.stock_location_cardboxes_bin_1",
+            "stock_storage_type.stock_location_cardboxes_bin_2",
+            "stock_storage_type.stock_location_cardboxes_bin_3",
+        ]
+        other_leaves_xmlids = [
+            "stock_storage_type.stock_location_cardboxes_reserve_bin_1",
+            "stock_storage_type.stock_location_cardboxes_reserve_bin_2",
+            "stock_storage_type.stock_location_cardboxes_reserve_bin_3",
+            "stock_storage_type.stock_location_pallets_reserve_bin_1",
+            "stock_storage_type.stock_location_pallets_reserve_bin_2",
+            "stock_storage_type.stock_location_pallets_reserve_bin_3",
+            "stock_storage_type.stock_location_pallets_bin_1",
+            "stock_storage_type.stock_location_pallets_bin_2",
+            "stock_storage_type.stock_location_pallets_bin_3",
+            "stock.stock_location_components",
+            "stock.location_refrigerator_small",
+        ]
+        cardboxes_leaves = self.env["stock.location"].union(
+            *[self.env.ref(xmlid) for xmlid in cardboxes_xmlids]
+        )
+        all_stock_leaves = (
+            self.env["stock.location"].union(
+                *[self.env.ref(xmlid) for xmlid in other_leaves_xmlids]
+            )
+            | cardboxes_leaves
+        )
+
+        self.assertEqual(self.cardboxes_stock.leaf_location_ids, cardboxes_leaves)
+        self.assertEqual(self.stock_location.leaf_location_ids, all_stock_leaves)
+
+    def test_location_leaf_locations_on_leaf(self):
+        self.assertEqual(self.cardboxes_bin_3.leaf_location_ids, self.cardboxes_bin_3)

--- a/stock_storage_type/tests/test_storage_type_move.py
+++ b/stock_storage_type/tests/test_storage_type_move.py
@@ -322,32 +322,33 @@ class TestStorageTypeMove(TestStorageTypeCommon):
                 | pack_level.location_dest_id
             )
 
-        for pack_level in int_picking.package_level_ids:
-            if pack_level.package_id == first_package:
-                # Pallet into pallets bin
-                self.assertEqual(
-                    pack_level.location_dest_id, self.pallets_bin_1_location
-                )
-            elif pack_level.package_id == second_pack:
-                # Cardbox into cardbox bin
-                self.assertEqual(
-                    pack_level.location_dest_id, self.cardboxes_bin_1_location
-                )
-            elif pack_level.package_id == third_pack:
-                # Cardbox with different product go into different cardbox location
-                self.assertEqual(
-                    pack_level.location_dest_id, self.cardboxes_bin_2_location
-                )
-            elif pack_level.package_id in (fourth_pack | fifth_pack):
-                # Cardbox with same product but different lot go into different
-                # cardbox location
-                # Cardbox with same product same lot go into same location
-                self.assertEqual(
-                    pack_level.location_dest_id, self.cardboxes_bin_3_location
-                )
-            else:
-                # We shouldn't get there
-                raise
+        def _levels_for(packages):
+            return self.env["stock.package_level"].search([("package_id", "in", packages.ids), ("picking_id", "=", int_picking.id)])
+
+        first_level = _levels_for(first_package)
+        self.assertEqual(len(first_level), 1)
+        # Pallet into pallets bin
+        self.assertEqual(first_level.location_dest_id, self.pallets_bin_1_location)
+
+        second_level = _levels_for(second_pack)
+        # Cardbox into cardbox bin
+        self.assertEqual(len(second_level), 1)
+        self.assertEqual(second_level.location_dest_id, self.cardboxes_bin_1_location)
+
+        third_level = _levels_for(third_pack)
+
+        # Cardbox with different product go into different cardbox location
+        self.assertEqual(len(third_level), 1)
+        self.assertEqual(third_level.location_dest_id, self.cardboxes_bin_2_location)
+
+        fourth_fifth_levels = _levels_for(fourth_pack | fifth_pack)
+        # Cardbox with same product but different lot go into different
+        # cardbox location
+        # Cardbox with same product same lot go into same location
+        self.assertEqual(len(fourth_fifth_levels), 2)
+        self.assertEqual(fourth_fifth_levels.location_dest_id, self.cardboxes_bin_3_location)
+
+        for pack_level in first_level | second_level | third_level | fourth_fifth_levels:
             # Check domain
             self.assertEqual(
                 pack_level.allowed_location_dest_ids,
@@ -357,12 +358,6 @@ class TestStorageTypeMove(TestStorageTypeCommon):
             for move_line in pack_level.move_line_ids:
                 move_line.qty_done = move_line.product_uom_qty
 
-        second_pack_level = int_picking.package_level_ids.filtered(
-            lambda pl: pl.package_id == second_pack
-        )
-        third_pack_level = int_picking.package_level_ids.filtered(
-            lambda pl: pl.package_id == third_pack
-        )
-        second_pack_level.location_dest_id = third_pack_level.location_dest_id
+        second_level.location_dest_id = third_level.location_dest_id
         with self.assertRaises(ValidationError):
             int_picking.button_validate()

--- a/stock_storage_type/tests/test_storage_type_move.py
+++ b/stock_storage_type/tests/test_storage_type_move.py
@@ -164,7 +164,7 @@ class TestStorageTypeMove(TestStorageTypeCommon):
                     ).ids,
                 ),
                 ("location_id", "child_of", int_picking.location_dest_id.id),
-                ("id", "in", package_type_locations.mapped("children_ids").ids),
+                ("id", "in", package_type_locations.mapped("leaf_location_ids").ids),
             ]
         )
         only_empty_possible_locations = possible_locations.filtered(
@@ -299,7 +299,7 @@ class TestStorageTypeMove(TestStorageTypeCommon):
         def _get_possible_locations(package_level):
             storage_type = package_level.package_id.package_storage_type_id
             package_type_locations = storage_type.storage_location_sequence_ids.mapped(
-                "location_id.children_ids"
+                "location_id.leaf_location_ids"
             )
             possible_locations = self.env["stock.location"].search(
                 [

--- a/stock_storage_type/tests/test_storage_type_move.py
+++ b/stock_storage_type/tests/test_storage_type_move.py
@@ -323,7 +323,12 @@ class TestStorageTypeMove(TestStorageTypeCommon):
             )
 
         def _levels_for(packages):
-            return self.env["stock.package_level"].search([("package_id", "in", packages.ids), ("picking_id", "=", int_picking.id)])
+            return self.env["stock.package_level"].search(
+                [
+                    ("package_id", "in", packages.ids),
+                    ("picking_id", "=", int_picking.id),
+                ]
+            )
 
         first_level = _levels_for(first_package)
         self.assertEqual(len(first_level), 1)
@@ -346,9 +351,13 @@ class TestStorageTypeMove(TestStorageTypeCommon):
         # cardbox location
         # Cardbox with same product same lot go into same location
         self.assertEqual(len(fourth_fifth_levels), 2)
-        self.assertEqual(fourth_fifth_levels.location_dest_id, self.cardboxes_bin_3_location)
+        self.assertEqual(
+            fourth_fifth_levels.location_dest_id, self.cardboxes_bin_3_location
+        )
 
-        for pack_level in first_level | second_level | third_level | fourth_fifth_levels:
+        for pack_level in (
+            first_level | second_level | third_level | fourth_fifth_levels
+        ):
             # Check domain
             self.assertEqual(
                 pack_level.allowed_location_dest_ids,

--- a/stock_storage_type/tests/test_storage_type_move.py
+++ b/stock_storage_type/tests/test_storage_type_move.py
@@ -71,13 +71,18 @@ class TestStorageTypeMove(TestStorageTypeCommon):
             move.move_line_ids.location_dest_id, self.pallets_bin_1_location
         )
 
-    def test_do_not_mix_products_confirmed_move(self):
+    def test_do_not_mix_products_confirmed_move_ok(self):
         self.pallets_location_storage_type.write(
             {"only_empty": False, "do_not_mix_products": True}
         )
         move = self._test_confirmed_move()
         self.assertEqual(
             move.move_line_ids.location_dest_id, self.pallets_bin_1_location
+        )
+
+    def test_do_not_mix_products_confirmed_move_nok(self):
+        self.pallets_location_storage_type.write(
+            {"only_empty": False, "do_not_mix_products": True}
         )
         move_other_product = self._test_confirmed_move(
             self.env.ref("product.product_product_10")

--- a/stock_storage_type/views/stock_package_level.xml
+++ b/stock_storage_type/views/stock_package_level.xml
@@ -1,3 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
+    <record id="package_level_form_view_inherit" model="ir.ui.view">
+        <field name="name">Package Level Inherit</field>
+        <field name="model">stock.package_level</field>
+        <field name="inherit_id" ref="stock.package_level_form_view" />
+        <field name="arch" type="xml">
+            <field name="location_dest_id" position="before">
+                <field
+                    name="allowed_location_dest_ids"
+                    widget="many2many_tags"
+                    groups="base.group_no_one"
+                    attrs="{'invisible': [('picking_type_code', '=', 'outgoing')]}"
+                />
+            </field>
+            <field name="location_dest_id" position="attributes">
+                <attribute
+                    name="domain"
+                >[('id', 'in', allowed_location_dest_ids)]</attribute>
+            </field>
+        </field>
+    </record>
+    <record id="package_level_tree_view_picking_inherit" model="ir.ui.view">
+        <field name="name">Package Level Tree Picking Inherit</field>
+        <field name="model">stock.package_level</field>
+        <field name="inherit_id" ref="stock.package_level_tree_view_picking" />
+        <field name="arch" type="xml">
+            <field name="location_dest_id" position="before">
+                <field name="allowed_location_dest_ids" invisible="1" />
+            </field>
+            <field name="location_dest_id" position="attributes">
+                <attribute
+                    name="domain"
+                >[('id', 'in', allowed_location_dest_ids)]</attribute>
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
The choice of a suitable stock location was implemented using an iteration on all candidate locations  + several filters running for each. This is not efficient when we have several 1000s of locations (each
check was taking 30ms -> several minutes required to compute a putaway location). This commit reimplements the algorithm by using queries to select locations matching the rules. In order to be able to compute this using the ORM, we added some technical fields which should not harm performance too much.
